### PR TITLE
Use error-first callbacks

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
 --reporter spec
 --ui bdd
+--timeout 10000

--- a/test/serf.js
+++ b/test/serf.js
@@ -29,10 +29,10 @@ describe('Serf', function () {
     assert.equal(clients.one['force-leave'], clients.one.forceLeave)
   })
 
-
   describe('stats', function () {
     it('works', function (done) {
-      clients.one.stats({}, function (result) {
+      clients.one.stats({}, function (err, result) {
+        assert.ifError(err)
         assert.equal('agent-one', result.agent.name)
         done(result.Error === '' ? null : result.Error)
       })
@@ -47,12 +47,16 @@ describe('Serf', function () {
         stream.stop()
         done()
       })
+      stream.on('error', function (err) {
+        assert.ifError(err)
+      })
     })
   })
 
   describe('join', function () {
     it('works', function (done) {
-      clients.one.join({Existing: ['127.0.0.1:7947'], Replay: false}, function (result) {
+      clients.one.join({Existing: ['127.0.0.1:7947'], Replay: false}, function (err, result) {
+        assert.ifError(err)
         assert.equal(result.Num, 1)
         done(result.Error === '' ? null : result.Error)
       })
@@ -61,7 +65,8 @@ describe('Serf', function () {
 
   describe('members', function () {
     it('works', function (done) {
-      clients.one.members(function (result) {
+      clients.one.members(function (err, result) {
+        assert.ifError(err)
         assert.isArray(result.Members)
         assert.deepPropertyVal(result, 'Members.length', 2)
         done()
@@ -71,7 +76,8 @@ describe('Serf', function () {
 
   describe('stream+event', function () {
     it('works', function (done) {
-      clients.two.stream({Type: 'user:foo'}, function (data) {
+      clients.two.stream({Type: 'user:foo'}, function (err, data) {
+        assert.ifError(err)
         assert.equal('user', data.Event)
         assert.equal('foo', data.Name)
         assert.equal('test payload', data.Payload.toString())
@@ -87,7 +93,8 @@ describe('Serf', function () {
 
   describe('tags', function () {
     it('works', function (done) {
-      clients.one.tags({Tags: {key1: 'val1'}}, function () {
+      clients.one.tags({Tags: {key1: 'val1'}}, function (err) {
+        assert.ifError(err)
         done()
       })
     })
@@ -95,7 +102,8 @@ describe('Serf', function () {
 
   describe('members-filtered', function () {
     it('works', function (done) {
-      clients.one.membersFiltered({Tags: {key1: 'val1'}}, function (res) {
+      clients.one.membersFiltered({Tags: {key1: 'val1'}}, function (err, res) {
+        assert.ifError(err)
         assert.equal(res.Members.length, 1)
         assert.equal(res.Members[0].Name, 'agent-one')
         done()
@@ -104,9 +112,9 @@ describe('Serf', function () {
   })
 
   describe('query+stream+respond', function () {
-    // This test is flakey...
-    xit('works', function (done) {
-      clients.two.stream({Type: 'query'}, function (data) {
+    it('works', function (done) {
+      clients.two.stream({Type: 'query'}, function (err, data) {
+        assert.ifError(err)
         assert.equal(data.Event, 'query')
         assert.equal(data.Name, 'name')
         assert.equal(data.Payload.toString(), 'payload')
@@ -115,7 +123,8 @@ describe('Serf', function () {
         clients.two.respond({ID: ID, Payload: 'client two response'})
       })
       var opts = {Name: "name", Payload: "payload", Timeout: 1000000}
-      clients.one.query(opts, function (data) {
+      clients.one.query(opts, function (err, data) {
+        assert.ifError(err)
         if (data.Type === 'response') {
           assert.equal(data.Payload.toString(), 'client two response')
         } else if (data.Type === 'done') {
@@ -135,7 +144,8 @@ describe('Serf', function () {
 
   describe('get-coordinate', function () {
     it('works', function (done) {
-      clients.one.getCoordinate({Node: 'agent-one'}, function (res) {
+      clients.one.getCoordinate({Node: 'agent-one'}, function (err, res) {
+        assert.ifError(err)
         assert(res.Ok)
         assert.property(res, "Coord")
         done()
@@ -145,11 +155,16 @@ describe('Serf', function () {
 
   describe('leave', function () {
     it('works', function (done) {
-      clients.two.stream({Type: 'member-leave'}, function (data) {
+      clients.two.stream({Type: 'member-leave'}, function (err, data) {
+        assert.ifError(err)
         assert.equal(data.Members[0].Name, 'agent-one')
         done()
       })
-      clients.one.leave()
+      setTimeout(function () {
+        clients.one.leave(function (err) {
+          assert.ifError(err)
+        })
+      }, 250)
     })
   })
 })


### PR DESCRIPTION
1, Changes API to use node.js idiomatic error-first callbacks. The three streaming commands use the same API (text below copied from the updated README in this PR):

-

Listen via `on('data')` and `on('error')` listeners:

```js
var handler = client.stream({Type: '*'}); // returns instance of stream handler

handler.on('data', function (result) {
  // handle streaming message
  console.log(result);
  handler.stop(); // stop streaming
});

handler.on('error', console.error.bind(console)); // log errors
```

or, via a callback that will be invoked on every event instance:

```js
var handler = client.stream({Type: '*'}, function (err, result) {
  assert.ifError(err);
  console.log(result);
  handler.stop();
});
```

-

2, Clarifies that users should listen to 'error' on the socket itself (quote again):

-

The Serf client extends node.js's socket class. In addition to handling errors
passed to the command callbacks and errors raised on streams created by the
`monitor`, `stream` and `query` commands, you should subscribe to the client's
`'error'` event, which will be invoked in case of a socket error unrelated to a
Serf command (such as a network fault). If you do not, these errors will bubble
up and become uncaught exceptions.

```js
var client = Serf.connect({port: 7373}, function (err) {
  assert.ifError(err);
  /// do stuff
});

client.on('error', function (err) {
  // handle error
})
```

-

3, Fixes the 'leave' event so it ends the socket, preventing an ECONNRESET. This bug has been probably been around forever but was silently getting swallowed.