### PR TITLE
bug(): don't send empty object for bodyless cmds

### DIFF
--- a/serf.js
+++ b/serf.js
@@ -122,7 +122,7 @@ Serf.prototype.send = function (Command, hasResponse, body, cb) {
 
   if (typeof body === 'function') {
     cb = body
-    body = {}
+    body = null
   }
 
   // Setup listeners

--- a/test/serf.js
+++ b/test/serf.js
@@ -47,7 +47,7 @@ describe('Serf', function () {
   })
 
   it('stats', function (done) {
-    clients.one.stats({}, function (err, result) {
+    clients.one.stats(function (err, result) {
       assert.ifError(err)
       assert(result.agent.name === 'agent-one')
       done(result.Error === '' ? null : result.Error)


### PR DESCRIPTION
Was causing serf to retransmit response

```
  serf [0] sending header: {"Command":"stats","Seq":2} +1ms
  serf [0] sending body: {} +0ms
  serf [0] received {"Error":"","Seq":2} +1ms
  serf [0] received {"agent":{"name":"agent-one"},"runtime":{"cpu_count":"8","os":"windows","arch":"amd64","version":"go1.5.2","max_procs":"8","goroutines":"25"},"serf":{"query_queue":"0","encrypted":"false","members":"1","member_time":"1","event_time":"1","query_time":"1","intent_queue":"0","event_queue":"0","failed":"0","left":"0"},"tags":{},"event_handlers":{}} +0ms
    √ stats // callback fired here, not expecting any more response data
  serf [0] received {"Error":"","Seq":2} +2ms
  serf [0] received {"tags":{},"event_handlers":{},"agent":{"name":"agent-one"},"runtime":{"cpu_count":"8","os":"windows","arch":"amd64","version":"go1.5.2","max_procs":"8","goroutines":"25"},"serf":{"members":"1","left":"0","member_time":"1","event_queue":"0","encrypted":"false","failed":"0","event_time":"1","query_time":"1","intent_queue":"0","query_queue":"0"}} +0ms
```