### PR TITLE
Change streaming command callback to be invoked upon subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,52 @@
+## 1.0.0
+
+*As version 1.0.0, this represents the first stable API. Semver will be
+followed for all subsequent releases.*
+
+#### Improvements
+
+* **Breaking change** Use node.js-style error-first callbacks (#13, e3ed332)
+* **Breaking change** Invoke callback to `stream`, `query` and `monitor` after
+subscribing to the stream instead of on every data/error event. (4ca9ac7)
+* Implement all Serf methods (#15, c51fab5)
+* Add default connection syntax (#18, 160e461)
+
+#### Bug fixes
+
+* Invoke callbacks for commands without response bodies; fix listener leak
+(c51fab5)
+* Don't call the `connect` callback until after handshake completes (cca18c5)
+* Don't call the `stream.stop` callback until after stream is stopped (4ca9ac7)
+
+#### Other
+* Port coffeescript to javascript
+* Update msgpack dependency (5c0fc7d)
+* Update other dependencies (89379b8)
+
+## 0.1.3
+
+#### Improvements
+
+* Add camel-cased method aliases (29840bb)
+
+## 0.1.2
+
+#### Improvements
+
+* Add `stats` command (00cb1c9)
+
 ## 0.1.1
 
-IMPROVEMENTS:
+#### Improvements:
 
-* support [tags](https://github.com/ryanuber/serf/blob/86e7f8bf41124405fd2608ec261148510e44e61e/client/rpc_client.go#L193-L202) command
+* Support [tags](https://github.com/ryanuber/serf/blob/86e7f8bf41124405fd2608ec261148510e44e61e/client/rpc_client.go#L193-L202) command
 
 ## 0.1.0
 
-IMPROVEMENTS:
+#### Improvements:
 
-* customized streaming decoder
+* Customized streaming decoder
 
-BUG FIXES:
+#### Bug fixes
 
-* properly decode messages
+* Properly decode messages

--- a/README.md
+++ b/README.md
@@ -85,27 +85,40 @@ rejoin, however.
 
 #### serf.stream(body[, callback]) [(ref)](https://github.com/hashicorp/serf/blob/master/website/source/docs/agent/rpc.html.markdown#stream)
 
-Listen via `on('data')` and `on('error')` listeners:
+Returns an event emitter than can be handled with `'listen'`, `'data'`,
+`'error'`  and `'stop'` listeners. This is *not* a node.js Stream, so it cannot
+be piped, paused, etc. Messages are not buffered, so messages will be dropped
+if listeners are not attached.
+
+If a callback is provided, it will be added to the `'listen'` listeners.
+
+The returned emitter has a `stop` method that ends the stream. If a callback is
+provided, it will be added to the `'stop'` listeners.
 
 ```js
-var handler = client.stream({Type: '*'}); // returns instance of stream handler
-
-handler.on('data', function (result) {
-  // handle streaming message
-  console.log(result);
-  handler.stop(); // stop streaming
+var stream = client.stream({Type: '*'}, function (err) {
+  // Called after the stream is connected
+  assert.ifError(err);
 });
 
-handler.on('error', console.error.bind(console)); // log errors
-```
+stream.on('listen', function (err) {
+  // Also called after the stream is connected
+});
 
-or, via a callback that will be invoked on every event instance:
+stream.on('error', console.error.bind(console)); // log errors
 
-```js
-var handler = client.stream({Type: '*'}, function (err, result) {
-  assert.ifError(err);
+stream.on('data', function (result) {
+  // Handle streaming message
   console.log(result);
-  handler.stop();
+
+  // Stop streaming
+  stream.stop(function (err) {
+    // Called when the stream is stopped
+  });
+});
+
+stream.on('stop', function () {
+  // Also emitted when the stream is stopped
 });
 ```
 
@@ -114,8 +127,10 @@ var handler = client.stream({Type: '*'}, function (err, result) {
 Listen using the same syntax as `serf.stream`.
 
 #### serf.query(body, callback) [(ref)](https://github.com/hashicorp/serf/blob/master/website/source/docs/agent/rpc.html.markdown#query)
-Issues a new query. The callback is invoked for every response. Check the
-`Type` of the response, which may be 'ack', 'response' or 'done'.
+Issues a new query. Listen using the same syntax as `serf.stream`. There are
+three `Type`s of responses: 'ack', 'response' and 'done'. The 'data' event is
+invoked when any type of response is received. When the 'done' response is
+received, the 'stop' event will also be emitted.
 
 #### serf.respond(body[, callback]) [(ref)](https://github.com/hashicorp/serf/blob/master/website/source/docs/agent/rpc.html.markdown#respond)
 * `body` \<Object\> Of the form `{ID: number, Payload: string|bytes[, ...]}`

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ three `Type`s of responses: 'ack', 'response' and 'done'. The 'data' event is
 invoked when any type of response is received. When the 'done' response is
 received, the 'stop' event will also be emitted.
 
+Note that there appears to be a bug in Serf wherein responses are sometimes
+sent with the form `{From: '', Payload: null, Type: 'response'}`. You should
+check that `Payload` is not null before attempting to access it.
+
 #### serf.respond(body[, callback]) [(ref)](https://github.com/hashicorp/serf/blob/master/website/source/docs/agent/rpc.html.markdown#respond)
 * `body` \<Object\> Of the form `{ID: number, Payload: string|bytes[, ...]}`
 

--- a/stream.js
+++ b/stream.js
@@ -12,13 +12,12 @@ function Stream (client, seq) {
 util.inherits(Stream, EventEmitter)
 
 Stream.prototype.stop = function (cb) {
-  if (typeof cb !== 'function') cb = function () {}
+  var _this = this
   this._client.stop({
     Stop: this._seq
-  }, cb)
-  var _this = this
-  return process.nextTick(function () {
-    return _this.emit('stop')
+  }, function (err) {
+    if (typeof cb === 'function') cb(err)
+    _this.emit('stop')
   })
 }
 

--- a/test/serf.js
+++ b/test/serf.js
@@ -58,19 +58,16 @@ describe('Serf', function () {
     var stream = clients.one.monitor({LogLevel: 'DEBUG'})
     stream.once('data', function (result) {
       assert(typeof result.Log === 'string')
-      stream.stop()
-      done()
+      stream.stop(done)
     })
-    stream.on('error', function (err) {
-      assert.ifError(err)
-    })
+    stream.on('error', done)
   })
 
   it('join', function (done) {
     clients.one.join({Existing: ['127.0.0.1:7947'], Replay: false}, function (err, result) {
       assert.ifError(err)
       assert(result.Num === 1)
-      done(result.Error === '' ? null : result.Error)
+      done()
     })
   })
 
@@ -83,15 +80,37 @@ describe('Serf', function () {
     })
   })
 
-  it('stream', function (done) {
-    clients.two.stream({Type: 'user:foo'}, function (err, data) {
+  it('stream works with a "listen" callback', function (done) {
+    var stream = clients.two.stream({Type: 'user:foo'}, function (err) {
       assert.ifError(err)
+      clients.one.event({Name: 'foo', Payload: 'test payload', Coalesce: true}, function (err) {
+        assert.ifError(err)
+      })
+    })
+    stream.on('error', done)
+    stream.on('data', function (data) {
       assert(data.Event === 'user')
       assert(data.Name === 'foo')
       assert(data.Payload.toString() === 'test payload')
-      done()
+      stream.stop(done)
     })
-    clients.one.event({Name: 'foo', Payload: 'test payload', Coalesce: true})
+  })
+
+  it('stream works with a "listen" listener', function (done) {
+    var stream = clients.two.stream({Type: 'user:foo'})
+    stream.on('listen', function (err) {
+      assert.ifError(err)
+      clients.one.event({Name: 'foo', Payload: 'test payload', Coalesce: true}, function (err) {
+        assert.ifError(err)
+      })
+    })
+    stream.on('error', done)
+    stream.on('data', function (data) {
+      assert(data.Event === 'user')
+      assert(data.Name === 'foo')
+      assert(data.Payload.toString() === 'test payload')
+      stream.stop(done)
+    })
   })
 
   it('force-leave')
@@ -115,26 +134,32 @@ describe('Serf', function () {
   })
 
   it('query+stream+respond', function (done) {
-    clients.two.stream({Type: 'query'}, function (err, data) {
+    var queryStream = clients.two.stream({Type: 'query'}, function (err) {
       assert.ifError(err)
+      var opts = {Name: 'name', Payload: 'payload'}
+      var responseStream = clients.one.query(opts, function (err) {
+        assert.ifError(err)
+      })
+      responseStream.on('data', function (data) {
+        if (data.Type === 'response') {
+          assert(data.Payload.toString() === 'client two response')
+        }
+      })
+      responseStream.on('stop', function () {
+        queryStream.stop(done)
+      })
+    })
+
+    queryStream.on('data', function (data) {
       assert(data.Event === 'query')
       assert(data.Name === 'name')
       assert(data.Payload.toString() === 'payload')
       assert(typeof data.ID === 'number')
       var ID = data.ID
-      clients.two.respond({ID: ID, Payload: 'client two response'})
-    })
-    var opts = {Name: 'name', Payload: 'payload'}
-    setTimeout(function () {
-      clients.one.query(opts, function (err, data) {
+      clients.two.respond({ID: ID, Payload: 'client two response'}, function (err) {
         assert.ifError(err)
-        if (data.Type === 'response') {
-          assert(data.Payload.toString() === 'client two response')
-        } else if (data.Type === 'done') {
-          done()
-        }
       })
-    }, 250)
+    })
   })
 
   it('install-key')
@@ -155,15 +180,15 @@ describe('Serf', function () {
   })
 
   it('leave', function (done) {
-    clients.two.stream({Type: 'member-leave'}, function (err, data) {
+    var stream = clients.two.stream({Type: 'member-leave'}, function (err) {
       assert.ifError(err)
-      assert(data.Members[0].Name === 'agent-one')
-      done()
-    })
-    setTimeout(function () {
       clients.one.leave(function (err) {
         assert.ifError(err)
       })
-    }, 250)
+    })
+    stream.on('data', function (data) {
+      assert(data.Members[0].Name === 'agent-one')
+      done()
+    })
   })
 })

--- a/test/serf.js
+++ b/test/serf.js
@@ -141,7 +141,7 @@ describe('Serf', function () {
         assert.ifError(err)
       })
       responseStream.on('data', function (data) {
-        if (data.Type === 'response') {
+        if (data.Type === 'response' && data.Payload) {
           assert(data.Payload.toString() === 'client two response')
         }
       })


### PR DESCRIPTION
* The three streaming commands' (stream, query, monitor) callback is now invoked after subscribing, not when data is received.
* The stream 'stop' callback is invoked and 'stop' event emitted after the stop is acknowledged by the Serf agent.
* Clean up stream internals at the end of a query.

See comment in #21 -- 4ca9ac7 doesn't fix the tests, but 80928ce should for now.