### PR TITLE
Bumps dependencies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6
+    version: 8
   environment:
     PATH: $PATH:/tmp/serf/
 dependencies:

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "gitHead": "8299820b8f0d7301495e2b61f657ce7d7d03a241",
   "devDependencies": {
     "intelli-espower-loader": "^1.0.1",
-    "mocha": "^3.4.2",
-    "power-assert": "^1.4.2",
-    "standard": "^10.0.2"
+    "mocha": "^4.0.1",
+    "power-assert": "^1.4.4",
+    "standard": "^10.0.3"
   },
   "dependencies": {
-    "debug": "^2.6.8",
+    "debug": "^3.1.0",
     "msgpack-lite": "^0.1.26"
   }
 }


### PR DESCRIPTION
- Test with node v8 (currently in LTS).
- Fix a security concern by updating `debug`.
- Other general dependency updates.